### PR TITLE
[Fix] Set kalypso-system namespace for sample resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ cd KalypsoServing
 
 # Install CRDs
 make install
+
+# Create kalypso-system namespace
+kubectl create namespace kalypso-system
 ```
 
 ### 2. Run the Controller
@@ -75,6 +78,7 @@ apiVersion: serving.serving.kalypso.io/v1alpha1
 kind: KalypsoProject
 metadata:
   name: sample-project
+  namespace: kalypso-system
 spec:
   displayName: "GenAI Model Serving Demo"
   owner: "team-ai-research"
@@ -108,6 +112,7 @@ apiVersion: serving.serving.kalypso.io/v1alpha1
 kind: KalypsoApplication
 metadata:
   name: recommendation-application
+  namespace: kalypso-system
 spec:
   projectRef: "sample-project"
   description: "Product recommendation model serving application"
@@ -128,6 +133,7 @@ apiVersion: serving.serving.kalypso.io/v1alpha1
 kind: KalypsoTritonServer
 metadata:
   name: recommendation-v1
+  namespace: kalypso-system
 spec:
   applicationRef: "recommendation-application"
   storageUri: "s3://kalypso-models/recommendation/v1/"
@@ -157,7 +163,7 @@ kubectl apply -f config/samples/serving_v1alpha1_kalypsotritonserver.yaml
 
 ```sh
 # Check KalypsoProject status
-kubectl get kalypsoproject
+kubectl get kalypsoproject -n kalypso-system
 # NAME             PHASE   OWNER              AGE
 # sample-project   Ready   team-ai-research   1m
 
@@ -169,26 +175,29 @@ kubectl get ns -l kalypso-serving.io/project=sample-project
 # sample-project-stage   Active   1m
 
 # Check KalypsoApplication status
-kubectl get kalypsoapplication
+kubectl get kalypsoapplication -n kalypso-system
 # NAME                         PROJECT          PHASE   MODELS   AGE
 # recommendation-application   sample-project   Ready   1        1m
 
 # Check KalypsoTritonServer status
-kubectl get kalypsotritonserver
+kubectl get kalypsotritonserver -n kalypso-system
 # NAME               APPLICATION                  PHASE     REPLICAS   AVAILABLE   AGE
 # recommendation-v1  recommendation-application   Pending   2          0           1m
 
 # Check Deployment and Service
-kubectl get deployment,svc -l kalypso-serving.io/tritonserver=recommendation-v1
+kubectl get deployment,svc -n kalypso-system -l kalypso-serving.io/tritonserver=recommendation-v1
 ```
 
 ### 7. Cleanup
 
 ```sh
 # Delete all resources
-kubectl delete kalypsotritonserver --all
-kubectl delete kalypsoapplication --all
-kubectl delete kalypsoproject --all
+kubectl delete kalypsotritonserver --all -n kalypso-system
+kubectl delete kalypsoapplication --all -n kalypso-system
+kubectl delete kalypsoproject --all -n kalypso-system
+
+# Delete namespace
+kubectl delete namespace kalypso-system
 
 # Uninstall CRDs
 make uninstall

--- a/config/samples/serving_v1alpha1_kalypsoapplication.yaml
+++ b/config/samples/serving_v1alpha1_kalypsoapplication.yaml
@@ -7,6 +7,7 @@ metadata:
     kalypso-serving.io/tag-recsys: "true"
     kalypso-serving.io/tag-tensorflow: "true"
   name: recommendation-application
+  namespace: kalypso-system
 spec:
   projectRef: "sample-project"
   description: "Product recommendation model serving application"

--- a/config/samples/serving_v1alpha1_kalypsoproject.yaml
+++ b/config/samples/serving_v1alpha1_kalypsoproject.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/name: kalypsoserving
     app.kubernetes.io/managed-by: kustomize
   name: sample-project
+  namespace: kalypso-system
 spec:
   displayName: "GenAI Model Serving Demo"
   owner: "team-ai-research"

--- a/config/samples/serving_v1alpha1_kalypsotritonserver.yaml
+++ b/config/samples/serving_v1alpha1_kalypsotritonserver.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/name: kalypsoserving
     app.kubernetes.io/managed-by: kustomize
   name: recommendation-v1
+  namespace: kalypso-system
 spec:
   applicationRef: "recommendation-application"
   storageUri: "s3://kalypso-models/recommendation/v1/"


### PR DESCRIPTION
## Summary
Sample CR 파일들이 `kalypso-system` 네임스페이스에 생성되도록 수정합니다.

## Changes

### Sample YAML Files
- `config/samples/serving_v1alpha1_kalypsoproject.yaml`: `namespace: kalypso-system` 추가
- `config/samples/serving_v1alpha1_kalypsoapplication.yaml`: `namespace: kalypso-system` 추가
- `config/samples/serving_v1alpha1_kalypsotritonserver.yaml`: `namespace: kalypso-system` 추가

### README.md Updates
- QuickStart 섹션에 `kubectl create namespace kalypso-system` 단계 추가
- 예제 YAML에 `namespace: kalypso-system` 추가
- Verify Deployment 명령어에 `-n kalypso-system` 옵션 추가
- Cleanup 명령어에 `-n kalypso-system` 옵션 및 네임스페이스 삭제 단계 추가