### PR TITLE
[Feature] Add S3-compatible storage support and E2E test samples

### DIFF
--- a/api/v1alpha1/kalypsoapplication_types.go
+++ b/api/v1alpha1/kalypsoapplication_types.go
@@ -64,6 +64,10 @@ type StorageSpec struct {
 	// Region is the cloud region for storage
 	// +optional
 	Region string `json:"region,omitempty"`
+
+	// Endpoint is the S3-compatible endpoint URL (for MinIO, etc.)
+	// +optional
+	Endpoint string `json:"endpoint,omitempty"`
 }
 
 // ApplicationPhase represents the current phase of the application

--- a/config/crd/bases/serving.serving.kalypso.io_kalypsoapplications.yaml
+++ b/config/crd/bases/serving.serving.kalypso.io_kalypsoapplications.yaml
@@ -81,6 +81,10 @@ spec:
                 description: Storage defines common storage/secret configuration for
                   all TritonServers
                 properties:
+                  endpoint:
+                    description: Endpoint is the S3-compatible endpoint URL (for MinIO,
+                      etc.)
+                    type: string
                   region:
                     description: Region is the cloud region for storage
                     type: string

--- a/config/samples/minio-deployment.yaml
+++ b/config/samples/minio-deployment.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-pvc
+  namespace: minio
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: quay.io/minio/minio:latest
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - minio server /data --console-address :9001
+          env:
+            - name: MINIO_ROOT_USER
+              value: "minioadmin"
+            - name: MINIO_ROOT_PASSWORD
+              value: "minioadmin123"
+          ports:
+            - containerPort: 9000
+              name: api
+            - containerPort: 9001
+              name: console
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: minio
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001
+  type: ClusterIP
+

--- a/config/samples/models/add_sub/1/model.py
+++ b/config/samples/models/add_sub/1/model.py
@@ -1,0 +1,72 @@
+import json
+import numpy as np
+import triton_python_backend_utils as pb_utils
+
+
+class TritonPythonModel:
+    """Simple Add/Sub model for KalypsoServing demo.
+    
+    This model takes two input tensors (INPUT0, INPUT1) and produces:
+    - OUTPUT0: INPUT0 + INPUT1 (element-wise addition)
+    - OUTPUT1: INPUT0 - INPUT1 (element-wise subtraction)
+    """
+
+    def initialize(self, args):
+        """Initialize the model.
+        
+        Args:
+            args: Dictionary containing model configuration
+        """
+        self.model_config = json.loads(args['model_config'])
+        
+        # Get output configuration
+        output0_config = pb_utils.get_output_config_by_name(
+            self.model_config, "OUTPUT0")
+        output1_config = pb_utils.get_output_config_by_name(
+            self.model_config, "OUTPUT1")
+
+        # Convert Triton types to numpy types
+        self.output0_dtype = pb_utils.triton_string_to_numpy(
+            output0_config['data_type'])
+        self.output1_dtype = pb_utils.triton_string_to_numpy(
+            output1_config['data_type'])
+
+    def execute(self, requests):
+        """Process inference requests.
+        
+        Args:
+            requests: List of pb_utils.InferenceRequest
+            
+        Returns:
+            List of pb_utils.InferenceResponse
+        """
+        responses = []
+
+        for request in requests:
+            # Get input tensors
+            input0 = pb_utils.get_input_tensor_by_name(request, "INPUT0")
+            input1 = pb_utils.get_input_tensor_by_name(request, "INPUT1")
+
+            # Convert to numpy arrays
+            input0_data = input0.as_numpy()
+            input1_data = input1.as_numpy()
+
+            # Perform add and subtract operations
+            add_result = (input0_data + input1_data).astype(self.output0_dtype)
+            sub_result = (input0_data - input1_data).astype(self.output1_dtype)
+
+            # Create output tensors
+            output0_tensor = pb_utils.Tensor("OUTPUT0", add_result)
+            output1_tensor = pb_utils.Tensor("OUTPUT1", sub_result)
+
+            # Create inference response
+            inference_response = pb_utils.InferenceResponse(
+                output_tensors=[output0_tensor, output1_tensor])
+            responses.append(inference_response)
+
+        return responses
+
+    def finalize(self):
+        """Clean up resources."""
+        pass
+

--- a/config/samples/models/add_sub/config.pbtxt
+++ b/config/samples/models/add_sub/config.pbtxt
@@ -1,0 +1,37 @@
+name: "add_sub"
+backend: "python"
+max_batch_size: 8
+
+input [
+  {
+    name: "INPUT0"
+    data_type: TYPE_FP32
+    dims: [ 4 ]
+  },
+  {
+    name: "INPUT1"
+    data_type: TYPE_FP32
+    dims: [ 4 ]
+  }
+]
+
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_FP32
+    dims: [ 4 ]
+  },
+  {
+    name: "OUTPUT1"
+    data_type: TYPE_FP32
+    dims: [ 4 ]
+  }
+]
+
+instance_group [
+  {
+    count: 1
+    kind: KIND_CPU
+  }
+]
+

--- a/config/samples/serving_v1alpha1_kalypsoapplication.yaml
+++ b/config/samples/serving_v1alpha1_kalypsoapplication.yaml
@@ -17,4 +17,5 @@ spec:
     buildWorkflow: "./.github/workflow/ci.yaml"
   storage:
     secretName: "aws-s3-credentials"
-    region: "ap-northeast-2"
+    region: "us-east-1"
+    endpoint: "http://minio.minio.svc:9000"

--- a/config/samples/serving_v1alpha1_kalypsotritonserver.yaml
+++ b/config/samples/serving_v1alpha1_kalypsotritonserver.yaml
@@ -4,11 +4,11 @@ metadata:
   labels:
     app.kubernetes.io/name: kalypsoserving
     app.kubernetes.io/managed-by: kustomize
-  name: recommendation-v1
+  name: add-sub-server
   namespace: kalypso-system
 spec:
   applicationRef: "recommendation-application"
-  storageUri: "s3://kalypso-models/recommendation/v1/"
+  storageUri: "s3://minio.minio.svc:9000/models/"
   tritonConfig:
     image: "nvcr.io/nvidia/tritonserver"
     tag: "24.12-py3"
@@ -16,19 +16,14 @@ spec:
       - name: "log-verbose"
         value: "1"
     backendType: "python"
-    python_backend:
-      shmDefaultByteSize: 1048576
-      extraArgs:
-        preprocessing_mode: "standard"
-        debug: "true"
-  replicas: 2
+  replicas: 1
   resources:
     requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
       cpu: "500m"
       memory: "1Gi"
-    limits:
-      cpu: "1000m"
-      memory: "2Gi"
   networking:
     httpPort: 8000
     grpcPort: 8001


### PR DESCRIPTION
## Summary
S3 호환 스토리지 (MinIO 등) 지원 추가 및 E2E 테스트 샘플 추가

## Changes

### API Changes
- `StorageSpec`에 `endpoint` 필드 추가 (MinIO 등 S3 호환 스토리지용)

### Controller Changes
- KalypsoTritonServer 컨트롤러가 Application의 storage 설정에서 credentials 주입
- `AWS_ENDPOINT_URL`, `S3_ENDPOINT`, `AWS_DEFAULT_REGION` 환경변수 자동 설정
- `envFrom`을 통한 Secret 참조로 credentials 주입

### Sample Files
- `minio-deployment.yaml`: MinIO 테스트용 배포 매니페스트
- `models/add_sub/`: Triton Python backend 예제 모델
  - `config.pbtxt`: 모델 설정
  - `1/model.py`: Python 백엔드 구현 (덧셈/뺄셈)
- 기존 샘플 YAML 업데이트

## Test Results ✅

### Environment
- Cluster: kind-kind
- Storage: MinIO (S3-compatible)
- Model: add_sub (Python backend)

### Inference Test
**Request:**
```bash
curl http://localhost:8000/v2/models/add_sub/infer \
  -H "Content-Type: application/json" \
  -d '{
    "inputs": [
      {"name": "INPUT0", "shape": [1, 4], "datatype": "FP32", "data": [1.0, 2.0, 3.0, 4.0]},
      {"name": "INPUT1", "shape": [1, 4], "datatype": "FP32", "data": [4.0, 3.0, 2.0, 1.0]}
    ]
  }'
```

**Response:**
```json
{
  "model_name": "add_sub",
  "model_version": "1",
  "outputs": [
    {"name": "OUTPUT0", "data": [5.0, 5.0, 5.0, 5.0]},
    {"name": "OUTPUT1", "data": [-3.0, -1.0, 1.0, 3.0]}
  ]
}
```

## Related Issue
Closes #21