### PR TITLE
[Feat] Add GitHub Packages CI/CD and update deployment docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Run tests
+        run: make test
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+

--- a/README.md
+++ b/README.md
@@ -230,10 +230,26 @@ make uninstall
 
 ### Deploy to Cluster
 
-**Build and push your image to the location specified by `IMG`:**
+KalypsoServing uses GitHub Container Registry (ghcr.io) for container images. Images are automatically built and pushed on every merge to the `main` branch.
+
+**Using Pre-built Image (Recommended):**
 
 ```sh
-make docker-build docker-push IMG=<some-registry>/kalypsoserving:tag
+# Install CRDs
+make install
+
+# Deploy using the latest image from GitHub Packages
+make deploy IMG=ghcr.io/kalypsoserving/kalypsoserving:latest
+```
+
+**Building Your Own Image:**
+
+```sh
+# Build and push to GitHub Container Registry
+make docker-build docker-push IMG=ghcr.io/kalypsoserving/kalypsoserving:main
+
+# Or build and push with a specific tag
+make docker-build docker-push IMG=ghcr.io/kalypsoserving/kalypsoserving:v0.1.0
 ```
 
 **Install the CRDs into the cluster:**
@@ -245,7 +261,7 @@ make install
 **Deploy the Manager to the cluster with the image specified by `IMG`:**
 
 ```sh
-make deploy IMG=<some-registry>/kalypsoserving:tag
+make deploy IMG=ghcr.io/kalypsoserving/kalypsoserving:latest
 ```
 
 > **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin


### PR DESCRIPTION
## Summary
Update README.md to use GitHub Container Registry (ghcr.io) for container images and add GitHub Actions workflow for automated builds.

## Changes

### README.md Updates
- Replace `<some-registry>` with `ghcr.io/kalypsoserving/kalypsoserving`
- Add instructions for using pre-built images
- Document building with custom tags

### GitHub Actions Workflow (`.github/workflows/release.yml`)
- **Trigger**: Push to `main` branch or version tags (`v*`)
- **Registry**: GitHub Container Registry (ghcr.io)
- **Image Tags**:
  - `latest` (on main branch)
  - Git commit SHA
  - Semantic version (e.g., `v0.1.0`, `0.1`)
- **Platforms**: linux/amd64, linux/arm64
- **Features**:
  - Run tests before build
  - Docker layer caching with GitHub Actions cache
  - Multi-platform builds

## Closes
- #25