### PR TITLE
[Chore] Update Docker image name to kalypso-controller and fix metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: kalypsoserving/kalypso-controller
 
 jobs:
   build-and-push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
+LABEL org.opencontainers.image.source=https://github.com/kalypsoServing/KalypsoServing
+LABEL org.opencontainers.image.description="Kubernetes Operator for managing ML inference workloads with NVIDIA Triton Inference Server"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod


### PR DESCRIPTION
## Description
Update Docker image configuration to use a more descriptive name and correct metadata labels.

## Changes

### 1. Dockerfile Labels
- ✅ Update `org.opencontainers.image.source` to actual repository URL
- ✅ Update `org.opencontainers.image.description` to describe KalypsoServing
- ✅ Change `org.opencontainers.image.licenses` to `Apache-2.0`

### 2. GitHub Actions Workflow
- ✅ Change image name from `kalypsoserving/kalypsoserving` to `kalypsoserving/kalypso-controller`

## Impact
- More descriptive container image name (`kalypso-controller`)
- Proper OCI metadata labels for GitHub Packages
- Better alignment with Kubernetes Operator naming conventions

## Testing
- [x] Workflow file syntax is valid
- [x] Dockerfile labels follow OCI specification

## Related Issues
Fixes #31