### PR TITLE
chore: cleanup pre-commit config and enhance CRD validations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,4 @@
 repos:
-  # Golang hooks
-  - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: v1.0.0-rc.1
-    hooks:
-      # Format code with gofmt
-      - id: go-fmt
-        args: [-w]
-
-      # Run go vet
-      - id: go-vet-mod
-
-      # Tidy go.mod and go.sum
-      - id: go-mod-tidy
-
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,98 @@
+# KalypsoServing Context
+
+## Project Overview
+
+**KalypsoServing** is a Kubernetes operator designed to manage Machine Learning (ML) model serving infrastructure, leveraging NVIDIA Triton Inference Server. It simplifies the deployment and lifecycle management of ML models on Kubernetes.
+
+### Key Components (CRDs)
+
+*   **KalypsoProject**: Defines a logical workspace for ML projects, providing environment isolation (e.g., dev, stage, prod) and resource quotas.
+*   **KalypsoApplication**: Represents a logical grouping of serving units (Triton servers) within a project. It handles shared configurations like storage credentials.
+*   **KalypsoTritonServer**: The core workload resource that deploys and manages instances of NVIDIA Triton Inference Server. It supports configuration for:
+    *   Model storage (S3/GCS).
+    *   Compute resources (GPU/CPU/Memory).
+    *   Networking (HTTP/gRPC/Metrics ports).
+    *   Observability (Logging, Tracing, Profiling, Metrics).
+    *   Backend types (Python, TensorFlow, PyTorch, etc.).
+
+### Architecture
+
+The operator follows the standard Kubernetes controller pattern.
+*   **API**: defined in `api/v1alpha1/`.
+*   **Controllers**: Logic resides in `internal/controller/`.
+*   **Configuration**: Kustomize manifests in `config/`.
+
+## Building and Running
+
+The project uses a `Makefile` for standard operations.
+
+### Prerequisites
+
+*   Go 1.24.0+
+*   Docker (or compatible container tool)
+*   Kubernetes cluster (Kind, Minikube, or remote)
+*   `kubectl`
+
+### Key Commands
+
+*   **Install Dependencies:**
+    ```bash
+    make setup-envtest
+    ```
+*   **Build Binary:**
+    ```bash
+    make build
+    ```
+*   **Run Controller Locally:**
+    ```bash
+    make run
+    ```
+    *Note: Ensure you have a kubeconfig pointing to a valid cluster.*
+
+*   **Install CRDs to Cluster:**
+    ```bash
+    make install
+    ```
+
+*   **Uninstall CRDs:**
+    ```bash
+    make uninstall
+    ```
+
+*   **Build Docker Image:**
+    ```bash
+    make docker-build IMG=<your-image-tag>
+    ```
+
+*   **Deploy to Cluster:**
+    ```bash
+    make deploy IMG=<your-image-tag>
+    ```
+
+## Testing
+
+The project uses **Ginkgo** and **Gomega** for testing.
+
+*   **Unit & Integration Tests:**
+    Runs using `envtest` (simulated API server).
+    ```bash
+    make test
+    ```
+
+*   **End-to-End (E2E) Tests:**
+    Runs against a real cluster (defaults to creating a Kind cluster named `kalypsoserving-test-e2e`).
+    ```bash
+    make test-e2e
+    ```
+
+## Development Conventions
+
+*   **Framework**: Built with [Kubebuilder](https://book.kubebuilder.io/).
+*   **Code Style**: Standard Go conventions. Run `make fmt` and `make vet` before committing.
+*   **Linting**: Uses `golangci-lint`. Run `make lint`.
+*   **Directory Structure**:
+    *   `api/`: CRD definitions (Go structs).
+    *   `internal/controller/`: Reconcile logic.
+    *   `config/`: Kustomize configuration for CRDs, RBAC, and Manager.
+    *   `hack/`: Scripts and boilerplate.
+*   **Observability**: The `KalypsoTritonServer` CRD has extensive support for observability stacks (Loki, Tempo, Pyroscope, Prometheus), which should be considered when modifying the server spec.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ flowchart TB
 git clone https://github.com/kalypsoServing/KalypsoServing.git
 cd KalypsoServing
 
+# create kind
+kind create cluster
+
 # Install CRDs
 make install
 

--- a/config/crd/bases/serving.serving.kalypso.io_kalypsoprojects.yaml
+++ b/config/crd/bases/serving.serving.kalypso.io_kalypsoprojects.yaml
@@ -51,9 +51,6 @@ spec:
           spec:
             description: spec defines the desired state of KalypsoProject
             properties:
-              description:
-                description: Description provides a description of the project
-                type: string
               displayName:
                 description: DisplayName is the human-readable project name
                 type: string

--- a/config/crd/bases/serving.serving.kalypso.io_kalypsotritonservers.yaml
+++ b/config/crd/bases/serving.serving.kalypso.io_kalypsotritonservers.yaml
@@ -67,16 +67,22 @@ spec:
                     default: 8001
                     description: 'GrpcPort is the gRPC port (default: 8001)'
                     format: int32
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   httpPort:
                     default: 8000
                     description: 'HttpPort is the HTTP port (default: 8000)'
                     format: int32
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   metricsPort:
                     default: 8002
                     description: 'MetricsPort is the metrics port (default: 8002)'
                     format: int32
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                 type: object
               observability:
@@ -166,6 +172,7 @@ spec:
                 default: 1
                 description: 'Replicas is the number of replicas (default: 1)'
                 format: int32
+                minimum: 1
                 type: integer
               resources:
                 description: Resources defines K8s resource requests/limits
@@ -276,6 +283,7 @@ spec:
                         description: ShmDefaultByteSize is the shared memory size
                           in bytes
                         format: int64
+                        minimum: 0
                         type: integer
                     type: object
                   tag:

--- a/config/samples/serving_v1alpha1_kalypsoproject.yaml
+++ b/config/samples/serving_v1alpha1_kalypsoproject.yaml
@@ -20,7 +20,7 @@ spec:
       namespace: sample-project-stage
       description: "Pre-deployment verification stage"
     prod:
-      namespace: sample-project-prod
+      namespace: sample-project
       description: "Production environment"
       resourceQuota:
         limits:


### PR DESCRIPTION
## Summary
- Removed golang-specific pre-commit hooks to simplify pre-commit configuration
- Enhanced CRD validations with port range checks (1-65535) and minimum value constraints
- Added kind cluster setup instructions to README
- Cleaned up KalypsoProject CRD by removing unused description field
- Fixed sample project namespace naming
- Added GEMINI.md documentation

## Test plan
- [ ] Verify CRD installation with `make install`
- [ ] Validate port range enforcement in KalypsoTritonServer resources
- [ ] Confirm pre-commit hooks run successfully
- [ ] Test kind cluster setup instructions from README

🤖 Generated with [Claude Code](https://claude.com/claude-code)